### PR TITLE
Utiliser docling-ibm-models de préférence à YOLO (meilleure licence)

### DIFF
--- a/alexi/cli.py
+++ b/alexi/cli.py
@@ -12,20 +12,13 @@ import logging
 import sys
 from pathlib import Path
 
-from . import annotate, download, extract, index, search
-from .analyse import Analyseur, Bloc
-from .convert import Converteur, write_csv
-from .format import format_html
-from .label import DEFAULT_MODEL as DEFAULT_LABEL_MODEL
-from .label import Identificateur
-from .segment import DEFAULT_MODEL as DEFAULT_SEGMENT_MODEL
-from .segment import Segmenteur
-
 LOGGER = logging.getLogger("alexi")
 
 
 def convert_main(args: argparse.Namespace):
     """Convertir les PDF en CSV"""
+    from .convert import Converteur, write_csv
+
     if args.pages:
         pages = [max(1, int(x)) for x in args.pages.split(",")]
     else:
@@ -36,6 +29,9 @@ def convert_main(args: argparse.Namespace):
 
 def segment_main(args: argparse.Namespace):
     """Segmenter un CSV"""
+    from .convert import write_csv
+    from .segment import Segmenteur
+
     crf: Segmenteur
     crf = Segmenteur(args.model)
     reader = csv.DictReader(args.csv)
@@ -44,6 +40,9 @@ def segment_main(args: argparse.Namespace):
 
 def label_main(args: argparse.Namespace):
     """Étiquetter un CSV"""
+    from .convert import write_csv
+    from .label import Identificateur
+
     crf = Identificateur(args.model)
     reader = csv.DictReader(args.csv)
     write_csv(crf(reader), sys.stdout)
@@ -51,6 +50,9 @@ def label_main(args: argparse.Namespace):
 
 def html_main(args: argparse.Namespace):
     """Convertir un CSV segmenté et étiquetté en HTML"""
+    from .analyse import Analyseur, Bloc
+    from .format import format_html
+
     reader = csv.DictReader(args.csv)
     analyseur = Analyseur(args.csv.name, reader)
     if args.images is not None:
@@ -66,6 +68,8 @@ def html_main(args: argparse.Namespace):
 
 def json_main(args: argparse.Namespace):
     """Convertir un CSV segmenté et étiquetté en JSON"""
+    from .analyse import Analyseur, Bloc
+
     iob = csv.DictReader(args.csv)
     analyseur = Analyseur(args.csv.name, iob)
     if args.images:
@@ -79,6 +83,10 @@ def json_main(args: argparse.Namespace):
 
 def make_argparse() -> argparse.ArgumentParser:
     """Make the argparse"""
+    from . import annotate, download, extract, index, search
+    from .label import DEFAULT_MODEL as DEFAULT_LABEL_MODEL
+    from .segment import DEFAULT_MODEL as DEFAULT_SEGMENT_MODEL
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "-v", "--verbose", help="Émettre des messages", action="store_true"

--- a/alexi/extract.py
+++ b/alexi/extract.py
@@ -27,6 +27,11 @@ from alexi.segment import DEFAULT_MODEL_NOSTRUCT, Segmenteur
 from alexi.types import T_obj
 
 LOGGER = logging.getLogger("extract")
+LABELMAP = {
+    "Table": "Tableau",
+    "Picture": "Figure",
+    "Figure": "Figure",
+}
 
 
 def add_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -427,7 +432,7 @@ class Extracteur:
         if pdf_path and not self.no_images:
             LOGGER.info("Extraction d'images sous %s", imgdir)
             imgdir.mkdir(parents=True, exist_ok=True)
-            images = self.obj(pdf_path)
+            images = self.obj(pdf_path, labelmap=LABELMAP)
             analyseur.add_images(images)
             save_images_from_pdf(analyseur.blocs, pdf_path, imgdir)
         LOGGER.info("Analyse de la structure de %s", fileid)

--- a/alexi/recognize/__init__.py
+++ b/alexi/recognize/__init__.py
@@ -18,7 +18,7 @@ import operator
 from collections import deque
 from os import PathLike
 from pathlib import Path
-from typing import Iterable, Iterator, Union
+from typing import Iterable, Iterator, Type, Union
 
 import pdfplumber
 from pdfplumber.page import Page
@@ -59,6 +59,21 @@ def get_element_bbox(page: Page, el: PDFStructElement, mcids: Iterable[int]) -> 
 
 class Objets:
     """Classe de base pour les détecteurs d'objects."""
+
+    @classmethod
+    def byname(cls, name: str) -> Type["Objets"]:
+        # We do not want to use a dictionary here because these should
+        # be imported lazily (so as to avoid dependencies)
+        if name == "yolo":
+            from alexi.recognize.yolo import ObjetsYOLO
+
+            return ObjetsYOLO
+        elif name == "docling":
+            from alexi.recognize.docling import ObjetsDocling
+
+            return ObjetsDocling
+        else:
+            return cls
 
     def __call__(
         self, pdf_path: PathLike, pages: Union[None, Iterable[int]] = None

--- a/alexi/recognize/__init__.py
+++ b/alexi/recognize/__init__.py
@@ -76,7 +76,10 @@ class Objets:
             return cls
 
     def __call__(
-        self, pdf_path: PathLike, pages: Union[None, Iterable[int]] = None
+        self,
+        pdf_path: PathLike,
+        pages: Union[None, Iterable[int]] = None,
+        labelmap: Union[None, dict] = None,
     ) -> Iterator[Bloc]:
         """Extraire les rectangles correspondant aux objets qui seront
         représentés par des images."""
@@ -130,7 +133,7 @@ class Objets:
                 d.extend(el.children)
 
         def make_bloc(
-            el: PDFStructElement, page_number: int, mcids: Iterable[int]
+            el: PDFStructElement, page_number: int, mcids: Iterable[int], name: str
         ) -> Bloc:
             page = pdf.pages[page_number - 1]
             x0, top, x1, bottom = get_element_bbox(page, el, mcids)
@@ -148,4 +151,8 @@ class Objets:
             mcids.sort()
             for page_number, group in itertools.groupby(mcids, operator.itemgetter(0)):
                 if page_number in pageset:
-                    yield make_bloc(el, page_number, (mcid for _, mcid in group))
+                    if labelmap is None or el.type in labelmap:
+                        name = el.type if labelmap is None else labelmap[el.type]
+                        yield make_bloc(
+                            el, page_number, (mcid for _, mcid in group), name
+                        )

--- a/alexi/recognize/docling.py
+++ b/alexi/recognize/docling.py
@@ -1,0 +1,114 @@
+"""Analyse de mise en page avec modèle RT-DETR de IBM (Docling)"""
+
+import logging
+from os import PathLike
+from pathlib import Path
+from typing import Iterable, Iterator, Union
+
+from docling_ibm_models.layoutmodel.layout_predictor import (  # type: ignore
+    LayoutPredictor,
+)
+from pypdfium2 import PdfDocument, PdfPage  # type: ignore
+
+from alexi.analyse import Bloc
+from alexi.recognize import Objets
+
+LOGGER = logging.getLogger(Path(__file__).stem)
+LABELMAP = {
+    "Table": "Tableau",
+    "Picture": "Figure",
+}
+
+
+def scale_to_model(page: PdfPage, modeldim: float):
+    """Find scaling factor for model dimension."""
+    mindim = min(page.get_width(), page.get_height())
+    return modeldim / mindim
+
+
+def load_model_from_hub() -> Path:
+    from huggingface_hub import hf_hub_download
+
+    hf_hub_download(
+        "ds4sd/docling-models", "model_artifacts/layout/preprocessor_config.json"
+    )
+    hf_hub_download("ds4sd/docling-models", "model_artifacts/layout/config.json")
+    weights_path = hf_hub_download(
+        "ds4sd/docling-models", "model_artifacts/layout/model.safetensors"
+    )
+    return Path(weights_path).parent
+
+
+class ObjetsDocling(Objets):
+    """Détecteur d'objects textuels utilisant RT-DETR."""
+
+    def __init__(
+        self,
+        model_path: Union[str, PathLike, None] = None,
+        device: str = "cpu",
+        num_threads: int = 4,
+        base_threshold: float = 0.3,
+    ) -> None:
+        if model_path is None:
+            model_path = load_model_from_hub()
+        else:
+            model_path = Path(model_path)
+        self.model = LayoutPredictor(
+            model_path,
+            device=device,
+            num_threads=num_threads,
+            base_threshold=base_threshold,
+        )
+        self.model_info = self.model.info()
+
+    def __call__(
+        self, pdf_path: Union[str, PathLike], pages: Union[None, Iterable[int]] = None
+    ) -> Iterator[Bloc]:
+        pdf_path = Path(pdf_path)
+        pdf = PdfDocument(pdf_path)
+        if pages is None:
+            pages = range(1, len(pdf) + 1)
+        for page_number in pages:
+            page = pdf[page_number - 1]
+            scale = scale_to_model(page, self.model_info["image_size"])
+            image = page.render(scale=scale).to_pil()
+
+            def boxsort(box):
+                """Sort by topmost-leftmost-tallest-widest."""
+                return (
+                    box["t"],
+                    box["l"],
+                    -(box["b"] - box["t"]),
+                    -(box["r"] - box["l"]),
+                )
+
+            boxes = sorted(self.model.predict(image), key=boxsort)
+            for box in boxes:
+                if box["label"] in LABELMAP:
+                    bbox = tuple(
+                        round(x / scale)
+                        for x in (box["l"], box["t"], box["r"], box["b"])
+                    )
+                    yield Bloc(
+                        type=LABELMAP[box["label"]],
+                        contenu=[],
+                        _page_number=page_number,
+                        _bbox=bbox,
+                    )
+        pdf.close()
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pdf", type=Path)
+    args = parser.parse_args()
+
+    recx = ObjetsDocling()
+    for bloc in recx(args.pdf):
+        print(bloc)
+
+
+if __name__ == "__main__":
+    main()

--- a/alexi/recognize/docling.py
+++ b/alexi/recognize/docling.py
@@ -5,9 +5,7 @@ from os import PathLike
 from pathlib import Path
 from typing import Iterable, Iterator, Union
 
-from docling_ibm_models.layoutmodel.layout_predictor import (  # type: ignore
-    LayoutPredictor,
-)
+from docling_ibm_models.layoutmodel.layout_predictor import LayoutPredictor
 from pypdfium2 import PdfDocument, PdfPage  # type: ignore
 
 from alexi.analyse import Bloc

--- a/alexi/recognize/docling.py
+++ b/alexi/recognize/docling.py
@@ -54,7 +54,7 @@ class ObjetsDocling(Objets):
         else:
             model_path = Path(model_path)
         self.model = LayoutPredictor(
-            model_path,
+            str(model_path),
             device=device,
             num_threads=num_threads,
             base_threshold=base_threshold,

--- a/alexi/recognize/yolo.py
+++ b/alexi/recognize/yolo.py
@@ -9,7 +9,7 @@ from typing import Iterable, Iterator, Union
 import numpy as np
 from huggingface_hub import hf_hub_download  # type: ignore
 from pdfplumber.utils.geometry import obj_to_bbox
-from pypdfium2 import PdfDocument, PdfPage
+from pypdfium2 import PdfDocument, PdfPage  # type: ignore
 from ultralytics import YOLO  # type: ignore
 
 from alexi import segment
@@ -82,11 +82,13 @@ class ObjetsYOLO(Objets):
             )
             labels = [entry.names[entry.boxes.cls[idx].item()] for idx in ordering]
             img_height, img_width = entry.orig_shape
-            LOGGER.info("scale x %f", page.width / img_width)
-            LOGGER.info("scale y %f", page.height / img_height)
+            page_width = page.get_width()
+            page_height = page.get_height()
+            LOGGER.info("scale x %f", page_width / img_width)
+            LOGGER.info("scale y %f", page_height / img_height)
             boxes = np.array(box_list)
-            boxes[:, [0, 2]] = boxes[:, [0, 2]] * page.width / img_width
-            boxes[:, [1, 3]] = boxes[:, [1, 3]] * page.height / img_height
+            boxes[:, [0, 2]] = boxes[:, [0, 2]] * page_width / img_width
+            boxes[:, [1, 3]] = boxes[:, [1, 3]] * page_height / img_height
             for label, box in zip(labels, boxes):
                 if label in LABELMAP:
                     yield Bloc(

--- a/alexi/recognize/yolo.py
+++ b/alexi/recognize/yolo.py
@@ -1,20 +1,14 @@
-import argparse
-import csv
 import logging
-import re
 from os import PathLike
 from pathlib import Path
 from typing import Iterable, Iterator, Union
 
 import numpy as np
 from huggingface_hub import hf_hub_download  # type: ignore
-from pdfplumber.utils.geometry import obj_to_bbox
 from pypdfium2 import PdfDocument, PdfPage  # type: ignore
 from ultralytics import YOLO  # type: ignore
 
-from alexi import segment
 from alexi.analyse import Bloc
-from alexi.convert import FIELDNAMES
 from alexi.recognize import Objets
 
 LOGGER = logging.getLogger(Path(__file__).stem)
@@ -24,12 +18,6 @@ def scale_to_model(page: PdfPage, modeldim: float):
     """Find scaling factor for model dimension."""
     maxdim = max(page.get_width(), page.get_height())
     return modeldim / maxdim
-
-
-LABELMAP = {
-    "Table": "Tableau",
-    "Picture": "Figure",
-}
 
 
 class ObjetsYOLO(Objets):
@@ -46,7 +34,10 @@ class ObjetsYOLO(Objets):
         self.model = YOLO(str(yolo_weights))
 
     def __call__(
-        self, pdf_path: Union[str, PathLike], pages: Union[None, Iterable[int]] = None
+        self,
+        pdf_path: Union[str, PathLike],
+        pages: Union[None, Iterable[int]] = None,
+        labelmap: Union[dict, None] = None,
     ) -> Iterator[Bloc]:
         """Extraire les rectangles correspondant aux objets"""
         pdf_path = Path(pdf_path)
@@ -90,128 +81,12 @@ class ObjetsYOLO(Objets):
             boxes[:, [0, 2]] = boxes[:, [0, 2]] * page_width / img_width
             boxes[:, [1, 3]] = boxes[:, [1, 3]] * page_height / img_height
             for label, box in zip(labels, boxes):
-                if label in LABELMAP:
+                if labelmap is None or label in labelmap:
                     yield Bloc(
-                        type=LABELMAP[label],
+                        type=(label if labelmap is None else labelmap[label]),
                         contenu=[],
                         _page_number=page_number,
                         _bbox=tuple(box.round()),
                     )
-
-
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("pdf_or_png", type=Path)
-    parser.add_argument("csv", type=argparse.FileType("rt"))
-    parser.add_argument("out", type=argparse.FileType("wt"))
-    args = parser.parse_args()
-
-    yolo_model = hf_hub_download(
-        repo_id="DILHTWD/documentlayoutsegmentation_YOLOv8_ondoclaynet",
-        filename="yolov8x-doclaynet-epoch64-imgsz640-initiallr1e-4-finallr1e-5.pt",
-    )
-    docseg_model = YOLO(yolo_model)
-
-    if args.pdf_or_png.exists():
-        pdf = PdfDocument(args.pdf_or_png)
-        images = (page.render(scale=scale_to_model(page, 640)).to_pil() for page in pdf)
-    else:
-        pngdir = args.pdf_or_png.parent
-        pngre = re.compile(re.escape(args.pdf_or_png.name) + r"-(\d+)\.png")
-        pngs = []
-        for path in pngdir.iterdir():
-            m = pngre.match(path.name)
-            if m is None:
-                continue
-            pngs.append((int(m.group(1)), path))
-        images = (path for _idx, path in sorted(pngs))
-
-    reader = csv.DictReader(args.csv)
-    fieldnames = FIELDNAMES[:]
-    fieldnames.insert(0, "yolo")
-    writer = csv.DictWriter(args.out, fieldnames, extrasaction="ignore")
-    writer.writeheader()
-    for image, words in zip(images, segment.split_pages(reader)):
-        results = docseg_model(
-            source=image,
-            show_labels=True,
-            show_boxes=True,
-            show_conf=True,
-        )
-        assert len(results) == 1
-        entry = results[0]
-
-        # Probably should do some kind of spatial indexing
-        def boxsort(e):
-            """Sort by topmost-leftmost-tallest-widest."""
-            _, b = e
-            return (b[1], b[0], -(b[3] - b[1]), -(b[2] - b[0]))
-
-        if len(entry.boxes.xyxy) == 0:
-            continue
-        ordering, boxes = zip(
-            *sorted(
-                enumerate(bbox.cpu().numpy() for bbox in entry.boxes.xyxy),
-                key=boxsort,
-            )
-        )
-        labels = [entry.names[entry.boxes.cls[idx].item()] for idx in ordering]
-        page_width, page_height = float(words[0]["page_width"]), float(
-            words[0]["page_height"]
-        )
-        img_height, img_width = entry.orig_shape
-        print("scale x", page_width / img_width)
-        print("scale y", page_height / img_height)
-        boxes = np.array(boxes)
-        boxes[:, [0, 2]] = boxes[:, [0, 2]] * page_width / img_width
-        boxes[:, [1, 3]] = boxes[:, [1, 3]] * page_height / img_height
-        for label, box in zip(labels, boxes):
-            print(label, box)
-
-        # Boxes are (luckily) in the same coordinate system as
-        # pdfplumber. But... YOLO leaves off little bits of text
-        # particularly at the right edge, so we can't rely on
-        # containment to match them to words
-        def totally_contained(boxes, bbox):
-            return (
-                (bbox[[0, 1]] >= boxes[:, [0, 1]]) & (bbox[[2, 3]] <= boxes[:, [2, 3]])
-            ).all(1)
-
-        def mostly_contained(boxes, bbox):
-            """Calculate inverse ratio of bbox to its intersection with each box."""
-            # FIXME: This assumes boxes are normalized...
-            # print("box", bbox)
-            # print("boxes", boxes)
-            top_left = np.maximum(bbox[[0, 1]], boxes[:, [0, 1]])
-            bottom_right = np.minimum(bbox[[2, 3]], boxes[:, [2, 3]])
-            intersection = np.hstack((top_left, bottom_right))
-            # print("intersections", intersection)
-            area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
-            assert area >= 0
-            width = np.maximum((intersection[:, 2] - intersection[:, 0]), 0)
-            height = np.maximum((intersection[:, 3] - intersection[:, 1]), 0)
-            # print("width", width)
-            # print("height", height)
-            iarea = width * height
-            # print("area", area)
-            # print("iarea", iarea)
-            return iarea / area
-
-        prev_label = None
-        for w in words:
-            bbox = np.array([float(w) for w in obj_to_bbox(w)])
-            ratio = mostly_contained(boxes, bbox)
-            # print("ratio", ratio)
-            in_box = ratio.argmax()
-            in_ratio = ratio.max()
-            # print("in_box", in_box, "in_ratio", in_ratio)
-            # in_labels = [labels[idx] for idx, val in enumerate(ratio) if val > 0.5]
-            label = in_box if in_ratio > 0.5 else None
-            iob = "B" if label != prev_label else "I"
-            prev_label = label
-            w["yolo"] = f"{iob}-{labels[label]}" if label is not None else "O"
-            writer.writerow(w)
-
-
-if __name__ == "__main__":
-    main()
+            page.close()
+        pdf.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ yolo = [
     "huggingface-hub",
     "ultralytics",
 ]
+docling = [
+    "docling-ibm-models",
+]
 api = [
     "fastapi[standard]",
 ]
@@ -58,7 +61,7 @@ testpaths = ["test"]
 addopts = "--cov=alexi --cov-report html"
 
 [tool.hatch.envs.default]
-features = [ "dev", "api", "yolo" ]
+features = [ "dev", "api", "yolo", "docling" ]
 
 [tool.hatch.envs.default.env-vars]
 # Avoid downloading gigabytes of CUDA junk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ yolo = [
     "ultralytics",
 ]
 docling = [
-    "docling-ibm-models",
+    "docling-ibm-models>=3.3.1",
 ]
 api = [
     "fastapi[standard]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["test"]
 addopts = "--cov=alexi --cov-report html"
 
 [tool.hatch.envs.default]
-features = [ "dev", "api", "yolo", "docling" ]
+features = [ "dev", "api", "docling" ]
 
 [tool.hatch.envs.default.env-vars]
 # Avoid downloading gigabytes of CUDA junk

--- a/scripts/add_object_column.py
+++ b/scripts/add_object_column.py
@@ -1,0 +1,94 @@
+"""Ajouter une colonne avec la sortie du modele de reconnaissance
+d'objets dans les CSV d'entrainement"""
+
+import argparse
+import csv
+import itertools
+from operator import attrgetter
+from pathlib import Path
+
+import numpy as np
+from pdfplumber.utils.geometry import obj_to_bbox
+
+from alexi import segment
+from alexi.convert import FIELDNAMES
+from alexi.recognize import Objets
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-O",
+        "--object-model",
+        choices=["docling", "yolo"],
+        default="docling",
+        help="Modele pour detection d'objects",
+    )
+    parser.add_argument("pdf", type=Path)
+    parser.add_argument("csv", type=argparse.FileType("rt"))
+    parser.add_argument("out", type=argparse.FileType("wt"))
+    args = parser.parse_args()
+
+    obj = Objets.byname(args.object_model)()
+
+    reader = csv.DictReader(args.csv)
+    fieldnames = FIELDNAMES[:]
+    fieldnames.insert(0, "doclaynet")
+    writer = csv.DictWriter(args.out, fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for (page_number, blocs), words in zip(
+        itertools.groupby(obj(args.pdf), attrgetter("page_number")),
+        segment.split_pages(reader),
+    ):
+        blocs = list(blocs)
+        labels = [b.type for b in blocs]
+        boxes = np.array([b.bbox for b in blocs])
+
+        # Boxes are (luckily) in the same coordinate system as
+        # pdfplumber. But... YOLO leaves off little bits of text
+        # particularly at the right edge, so we can't rely on
+        # containment to match them to words
+        def totally_contained(boxes, bbox):
+            return (
+                (bbox[[0, 1]] >= boxes[:, [0, 1]]) & (bbox[[2, 3]] <= boxes[:, [2, 3]])
+            ).all(1)
+
+        def mostly_contained(boxes, bbox):
+            """Calculate inverse ratio of bbox to its intersection with each box."""
+            # FIXME: This assumes boxes are normalized...
+            # print("box", bbox)
+            # print("boxes", boxes)
+            top_left = np.maximum(bbox[[0, 1]], boxes[:, [0, 1]])
+            bottom_right = np.minimum(bbox[[2, 3]], boxes[:, [2, 3]])
+            intersection = np.hstack((top_left, bottom_right))
+            # print("intersections", intersection)
+            area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+            assert area >= 0
+            width = np.maximum((intersection[:, 2] - intersection[:, 0]), 0)
+            height = np.maximum((intersection[:, 3] - intersection[:, 1]), 0)
+            # print("width", width)
+            # print("height", height)
+            iarea = width * height
+            # print("area", area)
+            # print("iarea", iarea)
+            return iarea / area
+
+        prev_label = None
+        for w in words:
+            assert w["page"] == str(page_number)
+            bbox = np.array([float(w) for w in obj_to_bbox(w)])
+            ratio = mostly_contained(boxes, bbox)
+            # print("ratio", ratio)
+            in_box = ratio.argmax()
+            in_ratio = ratio.max()
+            # print("in_box", in_box, "in_ratio", in_ratio)
+            # in_labels = [labels[idx] for idx, val in enumerate(ratio) if val > 0.5]
+            label = in_box if in_ratio > 0.5 else None
+            iob = "B" if label != prev_label else "I"
+            prev_label = label
+            w["doclaynet"] = f"{iob}-{labels[label]}" if label is not None else "O"
+            writer.writerow(w)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_on_doclaynet.py
+++ b/scripts/eval_on_doclaynet.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from sklearn_crfsuite import metrics
 
-from alexi.segment import split_pages, filter_tab, load
+from alexi.segment import filter_tab, load, split_pages
 
 
 def main():

--- a/scripts/test_crf.py
+++ b/scripts/test_crf.py
@@ -8,13 +8,7 @@ from typing import Iterable
 import sklearn_crfsuite as crfsuite  # type: ignore
 from sklearn_crfsuite import metrics
 
-from alexi.segment import (
-    Segmenteur,
-    load,
-    page2features,
-    page2labels,
-    split_pages,
-)
+from alexi.segment import Segmenteur, load, page2features, page2labels, split_pages
 
 
 def make_argparse():

--- a/scripts/test_crf_voting.py
+++ b/scripts/test_crf_voting.py
@@ -7,13 +7,7 @@ from pathlib import Path
 
 from sklearn_crfsuite import metrics
 
-from alexi.segment import (
-    Segmenteur,
-    load,
-    page2features,
-    page2labels,
-    split_pages,
-)
+from alexi.segment import Segmenteur, load, page2features, page2labels, split_pages
 
 
 def make_argparse():

--- a/scripts/train_crf.py
+++ b/scripts/train_crf.py
@@ -14,13 +14,7 @@ from sklearn.metrics import make_scorer  # type: ignore
 from sklearn.model_selection import KFold, cross_validate  # type: ignore
 from sklearn_crfsuite import metrics
 
-from alexi.segment import (
-    load,
-    page2features,
-    page2labels,
-    split_pages,
-    filter_tab,
-)
+from alexi.segment import filter_tab, load, page2features, page2labels, split_pages
 
 LOGGER = logging.getLogger("train-crf")
 

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -4,6 +4,7 @@ import pytest
 from pdfplumber.utils.geometry import obj_to_bbox
 
 from alexi.convert import Converteur
+from alexi.extract import LABELMAP
 from alexi.recognize import Objets, bbox_contains
 
 try:
@@ -22,7 +23,7 @@ def test_extract_tables_and_figures() -> None:
     conv = Converteur(DATADIR / "pdf_figures.pdf")
     obj = Objets()
     words = list(conv.extract_words())
-    images = list(obj(DATADIR / "pdf_figures.pdf"))
+    images = list(obj(DATADIR / "pdf_figures.pdf", labelmap=LABELMAP))
     assert len(images) == 2
     table = next(img for img in images if img.type == "Tableau")
     figure = next(img for img in images if img.type == "Figure")
@@ -39,7 +40,7 @@ def test_extract_tables_and_figures_yolo() -> None:
     obj = ObjetsYOLO()
     words = list(conv.extract_words())
     # There will be 3 as YOLO "sees" the chart twice (with and without the legend)
-    images = list(obj(DATADIR / "pdf_figures.pdf"))
+    images = list(obj(DATADIR / "pdf_figures.pdf", labelmap=LABELMAP))
     table = next(img for img in images if img.type == "Tableau")
     figure = next(img for img in images if img.type == "Figure")
     for w in words:
@@ -54,7 +55,7 @@ def test_extract_tables_and_figures_docling() -> None:
     conv = Converteur(DATADIR / "pdf_figures.pdf")
     obj = ObjetsDocling()
     words = list(conv.extract_words())
-    images = list(obj(DATADIR / "pdf_figures.pdf"))
+    images = list(obj(DATADIR / "pdf_figures.pdf", labelmap=LABELMAP))
     table = next(img for img in images if img.type == "Tableau")
     figure = next(img for img in images if img.type == "Figure")
     for w in words:

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -10,6 +10,10 @@ try:
     from alexi.recognize.yolo import ObjetsYOLO
 except ImportError:
     ObjetsYOLO = None
+try:
+    from alexi.recognize.docling import ObjetsDocling
+except ImportError:
+    ObjetsDocling = None
 
 DATADIR = Path(__file__).parent / "data"
 
@@ -29,9 +33,8 @@ def test_extract_tables_and_figures() -> None:
             assert "Figure" in w["tagstack"]
 
 
+@pytest.mark.skipif(ObjetsYOLO is None, reason="No YOLO, won't go")
 def test_extract_tables_and_figures_yolo() -> None:
-    if ObjetsYOLO is None:
-        pytest.skip("No YOLO, won't go")
     conv = Converteur(DATADIR / "pdf_figures.pdf")
     obj = ObjetsYOLO()
     words = list(conv.extract_words())
@@ -46,6 +49,22 @@ def test_extract_tables_and_figures_yolo() -> None:
             assert "Figure" in w["tagstack"]
 
 
+@pytest.mark.skipif(ObjetsDocling is None, reason="Docling has flown the coop")
+def test_extract_tables_and_figures_docling() -> None:
+    conv = Converteur(DATADIR / "pdf_figures.pdf")
+    obj = ObjetsDocling()
+    words = list(conv.extract_words())
+    images = list(obj(DATADIR / "pdf_figures.pdf"))
+    table = next(img for img in images if img.type == "Tableau")
+    figure = next(img for img in images if img.type == "Figure")
+    for w in words:
+        if bbox_contains(table.bbox, obj_to_bbox(w)):
+            assert "Table" in w["tagstack"]
+        if bbox_contains(figure.bbox, obj_to_bbox(w)):
+            assert "Figure" in w["tagstack"]
+
+
 if __name__ == "__main__":
     test_extract_tables_and_figures()
     test_extract_tables_and_figures_yolo()
+    test_extract_tables_and_figures_docling()


### PR DESCRIPTION
YOLO est licencé GPLv3 alors que [docling-ibm-models](https://github.com/DS4SD/docling-ibm-models) est MIT.  La performance est très semblable (étant donné que les deux ont été entraînés sur DocLayNet à 640x640).

Pour le moment YOLO reste accessible mais n'est pas installé dans l'environnement défaut.